### PR TITLE
chore: Add helpers:pinGitHubActionDigests to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "docker:pinDigests"
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
This commit adds the "helpers:pinGitHubActionDigests" extension to the "renovate.json" file. This extension is added to the existing list of extensions in the file. The purpose of this change is to enable pinning the digests of GitHub Actions used in the project. This will ensure that the project uses specific versions of the GitHub Actions, providing stability and reproducibility.